### PR TITLE
treat assembly files as valid go

### DIFF
--- a/gvc.go
+++ b/gvc.go
@@ -122,12 +122,14 @@ func cleanup(path string, opts options) error {
 			// If the file's parent directory is a needed package, keep it.
 			if !info.IsDir() && filepath.Dir(lastVendorPath) == name {
 				if opts.onlyGo {
+					validGoSuffix := strings.HasSuffix(path, ".go") || strings.HasSuffix(path, ".s") // also include assembly files
+
 					if opts.noTests {
-						if strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+						if validGoSuffix && !strings.HasSuffix(path, "_test.go") {
 							keep = true
 						}
 					} else {
-						if strings.HasSuffix(path, ".go") {
+						if validGoSuffix {
 							keep = true
 						}
 					}


### PR DESCRIPTION
Currently glide-vc omits assembly files which removes too many files
rendering vendored dependencies having Go assembly uncompilable.
