### PR TITLE
Fix bug when comparing vendor paths during directory traversals

### DIFF
--- a/gvc.go
+++ b/gvc.go
@@ -137,7 +137,7 @@ func cleanup(path string, opts options) error {
 		keep := false
 		for _, name := range pkgList {
 			// If the file's parent directory is a needed package, keep it.
-			if !info.IsDir() && filepath.Dir(lastVendorPath) == name {
+			if !info.IsDir() && strings.HasPrefix(filepath.Dir(lastVendorPath), name) {
 				if opts.onlyCode {
 					if opts.noTests && strings.HasSuffix(path, "_test.go") {
 						keep = false


### PR DESCRIPTION
`lastVendorPath` usually could be an exact package name, but could be sometimes not exactly the same as the package name.

For example, let's assume glide-vc runs like this:

`
  $ glide vc --only-code --no-tests --no-legal-files \
    --keep="*golang.org/x/net/internal*"
`

When `lastVendorPath` becomes `"golang.org/x/net/internal/timeseries/timeseries.go"`, `filePath.Dir(lastVendorPath)` becomes `"golang.org/x/net/internal/timeseries"`, which would be never the same as `"golang.org/x/net/internal"`, the given package name. As its result, `"keep"` is always set to false, and then glide-vc cannot keep `"golang.org/x/net/internal"` at all.

Fix it by checking if `filePath.Dir(lastVendorPath)` contains the given package name as prefix.

I found it out working on https://github.com/coreos/fleet/pull/1662.
