### PR TITLE
Fix code and tests on windows.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ build_script:
 - go build
 
 test_script:
-- PATH=$GOPATH/bin:$PATH go test .
+- set PATH=%PATH%;%GOPATH%\bin
+- go test .
 
 deploy: off

--- a/gvc.go
+++ b/gvc.go
@@ -131,6 +131,9 @@ func cleanup(path string) error {
 	} else {
 		packages, err = glideListImports(path)
 	}
+	if err != nil {
+		return err
+	}
 
 	// The package list already have the path converted to the os specific
 	// path separator, needed for future comparisons.
@@ -187,7 +190,7 @@ func cleanup(path string) error {
 		keep := false
 
 		for _, name := range pkgList {
-			// If a directory is a needed package then keep it
+			// if a directory is a needed package then keep it
 			keep = keep || info.IsDir() && name == lastVendorPath
 
 			// The remaining tests are only for files
@@ -291,11 +294,11 @@ func getLastVendorPath(path string) (string, error) {
 }
 
 func isParentDirectory(parent, child string) bool {
-	if !strings.HasSuffix(parent, "/") {
-		parent += "/"
+	if !strings.HasSuffix(parent, string(filepath.Separator)) {
+		parent += string(filepath.Separator)
 	}
-	if !strings.HasSuffix(child, "/") {
-		child += "/"
+	if !strings.HasSuffix(child, string(filepath.Separator)) {
+		child += string(filepath.Separator)
 	}
 	return strings.HasPrefix(child, parent)
 }

--- a/gvc_test.go
+++ b/gvc_test.go
@@ -442,11 +442,11 @@ func TestGetLastVendorPath(t *testing.T) {
 	}
 
 	for input, expected := range tests {
-		got, err := getLastVendorPath(input)
+		got, err := getLastVendorPath(filepath.FromSlash(input))
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
-		if got != expected {
+		if got != filepath.FromSlash(expected) {
 			t.Fatalf("got=%q, expected=%q", got, expected)
 		}
 	}
@@ -467,9 +467,9 @@ func TestIsParentDirectory(t *testing.T) {
 	}
 
 	for input, expected := range tests {
-		got := isParentDirectory(input.Parent, input.Child)
+		got := isParentDirectory(filepath.FromSlash(input.Parent), filepath.FromSlash(input.Child))
 		if got != expected {
-			t.Fatalf("got=%q, expected=%q", got, expected)
+			t.Fatalf("got=%t, expected=%t", got, expected)
 		}
 	}
 }


### PR DESCRIPTION
Given that I absolutely don't care about windows, this fixes code and tests on
it.

PR #21 tried to set the PATH env var in an unix like way with the effect of
disabling the go test execution.

This patch:
- Fixes PATH env to add $GOPATH/bin
- Fixes isParentDirectory
- Fixes TestGetLastVendorPath and TestIsParentDirectory
- Handles missing error check on `glide list` execution

/cc @Fugiman 
