### PR TITLE
print errors to stderr and with trailing newlines

### DIFF
--- a/gvc.go
+++ b/gvc.go
@@ -65,12 +65,12 @@ func main() {
 
 func glidevc(cmd *cobra.Command, args []string) {
 	if opts.noTests && !opts.onlyCode {
-		fmt.Printf("--no-tests requires --only-code")
+		fmt.Fprintln(os.Stderr, "--no-tests requires --only-code")
 		os.Exit(1)
 	}
 
 	if err := cleanup("."); err != nil {
-		fmt.Print(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Just style nits, this isn't actually impacting my use of glide-vc.

Before:

    $ glide-vc --no-tests
    --no-tests requires --only-code$

After:

    $ glide-vc --no-tests
    --no-tests requires --only-code
    $