### PR TITLE
[POC] add keep-full flag to allow preservation of an entire vendor and subvendor dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Session.vim
 #
 bin/
 /gopath/
+
+# gogland
+.idea/


### PR DESCRIPTION
I found a need to preserve an entire top-level vendored project and all of its subvendor tree.

I was vendoring some kubernetes code-gen libraries for my types.  The normal path for making it work is to require k8s.io/code-generator (github.com/kubernetes/code-generator) and then to call a script in that repo. (Usage here if you're interested: https://github.com/openshift/kube-projects/blob/master/hack/update-generated.sh)

I've opened this pull to demonstrate one way to handle the preservation for this case.  In general, vendored  repos can include their own vendor trees which need different handling than the flat vendor case.

